### PR TITLE
feat: JWT에 사용자 nickname 포함

### DIFF
--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -34,7 +34,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, UserRole userRole) {
+    public String createToken(Long userId, String email, UserRole userRole, String nickname) {
         Date date = new Date();
 
         return BEARER_PREFIX +
@@ -42,6 +42,7 @@ public class JwtUtil {
                         .setSubject(String.valueOf(userId))
                         .claim("email", email)
                         .claim("userRole", userRole)
+                        .claim("nickname", nickname)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                         .setIssuedAt(date) // 발급일
                         .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/org/example/expert/domain/auth/dto/request/SignupRequest.java
@@ -17,4 +17,6 @@ public class SignupRequest {
     private String password;
     @NotBlank
     private String userRole;
+    @NotBlank
+    private String nickname;
 }

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -38,7 +38,8 @@ public class AuthService {
         User newUser = new User(
                 signupRequest.getEmail(),
                 encodedPassword,
-                userRole
+                userRole,
+                signupRequest.getNickname()
         );
         User savedUser = userRepository.save(newUser);
 

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
         );
         User savedUser = userRepository.save(newUser);
 
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole);
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole, savedUser.getNickname());
 
         return new SignupResponse(bearerToken);
     }
@@ -57,7 +57,7 @@ public class AuthService {
             throw new AuthException("잘못된 비밀번호입니다.");
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole());
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getUserRole(), user.getNickname());
 
         return new SigninResponse(bearerToken);
     }

--- a/src/main/java/org/example/expert/domain/user/entity/User.java
+++ b/src/main/java/org/example/expert/domain/user/entity/User.java
@@ -20,6 +20,7 @@ public class User extends Timestamped {
     private String password;
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
+    private String nickname;
 
     public User(String email, String password, UserRole userRole) {
         this.email = email;

--- a/src/main/java/org/example/expert/domain/user/entity/User.java
+++ b/src/main/java/org/example/expert/domain/user/entity/User.java
@@ -22,10 +22,11 @@ public class User extends Timestamped {
     private UserRole userRole;
     private String nickname;
 
-    public User(String email, String password, UserRole userRole) {
+    public User(String email, String password, UserRole userRole, String nickname) {
         this.email = email;
         this.password = password;
         this.userRole = userRole;
+        this.nickname = nickname;
     }
 
     private User(Long id, String email, UserRole userRole) {


### PR DESCRIPTION
## 작업 내용
- User 엔티티에 nickname 필드 추가
- JWT 발급 시 payload(claims)에 nickname 포함

## 테스트 결과
- 회원가입 및 로그인 시 발급되는 JWT payload에 nickname 확인

## 참고 사항
- nickname은 컨트롤러 레벨에서 `@NotBlank`로 설정되어 JWT 생성 시 항상 포함됨
- nickname 중복은 허용