### PR TITLE
fix: AdminAccessLoggingAspect AOP 적용 범위 및 동작 수정

### DIFF
--- a/src/main/java/org/example/expert/aop/AdminAccessLoggingAspect.java
+++ b/src/main/java/org/example/expert/aop/AdminAccessLoggingAspect.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -18,8 +19,8 @@ public class AdminAccessLoggingAspect {
 
     private final HttpServletRequest request;
 
-    @After("execution(* org.example.expert.domain.user.controller.UserController.getUser(..))")
-    public void logAfterChangeUserRole(JoinPoint joinPoint) {
+    @Before("execution(* org.example.expert.domain.user.controller.UserAdminController.changeUserRole(..))")
+    public void logBeforeChangeUserRole(JoinPoint joinPoint) {
         String userId = String.valueOf(request.getAttribute("userId"));
         String requestUrl = request.getRequestURI();
         LocalDateTime requestTime = LocalDateTime.now();


### PR DESCRIPTION
## 작업 내용
- `UserAdminController` 클래스의 `changeUserRole()` 메소드 실행 전 AOP 적용
- `AdminAccessLoggingAspect` 클래스에서 개발 의도에 맞게 AOP 포인트컷과 advice 수정

## 테스트 결과
- changeUserRole 호출 시 AOP가 정상적으로 동작하여 로그 기록 확인
