### PR TITLE
fix: N+1 문제를 fetch join으로 해결

### DIFF
--- a/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/org/example/expert/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package org.example.expert.domain.comment.repository;
 
 import org.example.expert.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("SELECT c FROM Comment c JOIN c.user WHERE c.todo.id = :todoId")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.todo.id = :todoId")
     List<Comment> findByTodoIdWithUser(@Param("todoId") Long todoId);
 }


### PR DESCRIPTION
## 작업 내용
- Comment 연관관계 조회 시 발생하던 N+1 문제 fetch join을 통해 해결

## 테스트 결과
- API 호출 시 실행되는 쿼리 수 단일 쿼리로 감소 확인
- 기존 비즈니스 로직과 동일한 응답 결과 확인