### PR TITLE
feat: QueryDSL 적용 및 Todo 단건 조회 fetch join 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/expert/config/QueryDSLConfig.java
+++ b/src/main/java/org/example/expert/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package org.example.expert.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface TodoRepository extends JpaRepository<Todo, Long> {
+public interface TodoRepository extends JpaRepository<Todo, Long>, TodoRepositoryCustom {
 
     @Query("SELECT t FROM Todo t " +
             "LEFT JOIN FETCH t.user u " +
@@ -25,8 +25,8 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             @Param("endDateTime") LocalDateTime endDateTime
     );
 
-    @Query("SELECT t FROM Todo t " +
-            "LEFT JOIN t.user " +
-            "WHERE t.id = :todoId")
-    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
+//    @Query("SELECT t FROM Todo t " +
+//            "LEFT JOIN t.user " +
+//            "WHERE t.id = :todoId")
+//    Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
@@ -1,0 +1,9 @@
+package org.example.expert.domain.todo.repository;
+
+import org.example.expert.domain.todo.entity.Todo;
+
+import java.util.Optional;
+
+public interface TodoRepositoryCustom {
+    Optional<Todo> findByIdWithUser(Long todoId);
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
@@ -1,0 +1,23 @@
+package org.example.expert.domain.todo.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.todo.entity.Todo;
+
+import java.util.Optional;
+
+import static org.example.expert.domain.todo.entity.QTodo.todo;
+
+@RequiredArgsConstructor
+public class TodoRepositoryCustomImpl implements TodoRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<Todo> findByIdWithUser(Long todoId) {
+        return Optional.ofNullable(jpaQueryFactory.selectFrom(todo)
+                .where(todo.id.eq(todoId))
+                .leftJoin(todo.user).fetchJoin()
+                .fetchOne());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- QueryDSL 기반 커스텀 레포지토리 추가 (`TodoRepositoryCustom` / `TodoRepositoryCustomImpl`)
- 기존 TodoRepository에 커스텀 인터페이스 연동
- 특정 Todo 조회 시 User를 fetch join으로 함께 조회하도록 구현

## 테스트 결과
- Postman 테스트 완료