### PR TITLE
feat: QueryDSL 기반 Todo 검색 API 구현

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
+++ b/src/main/java/org/example/expert/domain/todo/controller/TodoController.java
@@ -7,6 +7,7 @@ import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.service.TodoService;
 import org.springframework.data.domain.Page;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -43,5 +44,17 @@ public class TodoController {
     @GetMapping("/todos/{todoId}")
     public ResponseEntity<TodoResponse> getTodo(@PathVariable long todoId) {
         return ResponseEntity.ok(todoService.getTodo(todoId));
+    }
+
+    @GetMapping("/todos/search")
+    public ResponseEntity<Page<TodoSearchResponse>> searchTodos(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String nickname,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate endDate,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(todoService.searchTodos(title, nickname, startDate, endDate, page, size));
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
+++ b/src/main/java/org/example/expert/domain/todo/dto/response/TodoSearchResponse.java
@@ -1,0 +1,19 @@
+package org.example.expert.domain.todo.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoSearchResponse {
+
+    private String title;
+    private int managerCount;
+    private int commentCount;
+
+    public TodoSearchResponse(String title, int managerCount, int commentCount) {
+        this.title = title;
+        this.managerCount = managerCount;
+        this.commentCount = commentCount;
+    }
+}

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustom.java
@@ -1,9 +1,14 @@
 package org.example.expert.domain.todo.repository;
 
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface TodoRepositoryCustom {
     Optional<Todo> findByIdWithUser(Long todoId);
+    Page<TodoSearchResponse> searchTodos(Pageable pageable, String title, String nickname, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
@@ -1,11 +1,27 @@
 package org.example.expert.domain.todo.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
+import static org.example.expert.domain.comment.entity.QComment.comment;
+import static org.example.expert.domain.manager.entity.QManager.manager;
 import static org.example.expert.domain.todo.entity.QTodo.todo;
 
 @RequiredArgsConstructor
@@ -19,5 +35,56 @@ public class TodoRepositoryCustomImpl implements TodoRepositoryCustom {
                 .where(todo.id.eq(todoId))
                 .leftJoin(todo.user).fetchJoin()
                 .fetchOne());
+    }
+
+    @Override
+    public Page<TodoSearchResponse> searchTodos(Pageable pageable, String title, String nickname, LocalDate startDate, LocalDate endDate) {
+
+        if (title == null && nickname == null && startDate == null && endDate == null) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        List<TodoSearchResponse> results = jpaQueryFactory.select(
+                        Projections.constructor(TodoSearchResponse.class,
+                                todo.title,
+                                manager.id.countDistinct().intValue(),
+                                comment.id.countDistinct().intValue()
+                        ))
+                .from(todo)
+                .leftJoin(todo.managers, manager)
+                .leftJoin(todo.comments, comment)
+                .where(titleLike(title), nicknameLike(nickname), betweenDate(startDate, endDate))
+                .groupBy(todo.id)
+                .orderBy(todo.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(todo.count())
+                .from(todo)
+                .where(titleLike(title), nicknameLike(nickname), betweenDate(startDate, endDate));
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression titleLike(String title) {
+        return title != null ? todo.title.contains(title) : null;
+    }
+
+    private BooleanExpression nicknameLike(String nickname) {
+        return nickname != null ? todo.user.nickname.contains(nickname) : null;
+    }
+
+    private BooleanExpression betweenDate(LocalDate startDate, LocalDate endDate) {
+        if (startDate != null && endDate != null) {
+            BooleanExpression isGoeStartDate = todo.createdAt.goe(LocalDateTime.of(startDate, LocalTime.MIN));
+            BooleanExpression isLoeEndDate = todo.createdAt.loe(LocalDateTime.of(endDate, LocalTime.MAX).withNano(0));
+
+
+            return Expressions.allOf(isGoeStartDate, isLoeEndDate);
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -7,6 +7,7 @@ import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.todo.dto.request.TodoSaveRequest;
 import org.example.expert.domain.todo.dto.response.TodoResponse;
 import org.example.expert.domain.todo.dto.response.TodoSaveResponse;
+import org.example.expert.domain.todo.dto.response.TodoSearchResponse;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
 import org.example.expert.domain.user.dto.response.UserResponse;
@@ -91,6 +92,18 @@ public class TodoService {
                 new UserResponse(user.getId(), user.getEmail()),
                 todo.getCreatedAt(),
                 todo.getModifiedAt()
+        );
+    }
+
+    public Page<TodoSearchResponse> searchTodos(String title, String nickname, LocalDate startDate, LocalDate endDate, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        return todoRepository.searchTodos(
+                pageable,
+                title,
+                nickname,
+                startDate,
+                endDate
         );
     }
 }


### PR DESCRIPTION
## 작업 내용
- QueryDSL을 사용하여 Todo 검색 기능 구현
   -  제목(부분 일치), 담당자 닉네임(부분 일치), 생성일 범위로 검색
   - 검색 결과 DTO: `TodoSearchResponse`
     -  제목(title), 담당자 수(managerCount), 댓글 수(commentCount)
- 결과 페이징처리
- 생성일 기준 최신 정렬

## 테스트 결과
- 검색 조건 없이 호출 시 빈값 반환
- 제목, 닉네임, 날짜 조건 별로 동적 필터링 정상 동작 확인
- 페이징과 정렬 정상 동작 확인
