### PR TITLE
refactor: QueryDSL 날짜 범위 조건 메서드 개선

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
@@ -82,14 +82,20 @@ public class TodoRepositoryCustomImpl implements TodoRepositoryCustom {
     }
 
     private BooleanExpression betweenDate(LocalDate startDate, LocalDate endDate) {
-        if (startDate != null && endDate != null) {
-            BooleanExpression isGoeStartDate = todo.createdAt.goe(LocalDateTime.of(startDate, LocalTime.MIN));
-            BooleanExpression isLoeEndDate = todo.createdAt.loe(LocalDateTime.of(endDate, LocalTime.MAX).withNano(0));
+        BooleanExpression condition = null;
 
-
-            return Expressions.allOf(isGoeStartDate, isLoeEndDate);
+        if (startDate != null) {
+            LocalDateTime startDateTime = LocalDateTime.of(startDate, LocalTime.MIN);
+            condition = todo.createdAt.goe(startDateTime);
         }
 
-        return null;
+        if (endDate != null) {
+            LocalDateTime endDateTime = LocalDateTime.of(endDate, LocalTime.MAX).withNano(0);
+            BooleanExpression endCondition = todo.createdAt.loe(endDateTime);
+
+            condition = (condition != null) ? condition.and(endCondition) : endCondition;
+        }
+
+        return condition;
     }
 }

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepositoryCustomImpl.java
@@ -40,7 +40,12 @@ public class TodoRepositoryCustomImpl implements TodoRepositoryCustom {
     @Override
     public Page<TodoSearchResponse> searchTodos(Pageable pageable, String title, String nickname, LocalDate startDate, LocalDate endDate) {
 
-        if (title == null && nickname == null && startDate == null && endDate == null) {
+        boolean hasSearchCondition = (title != null && !title.isBlank())
+                || (nickname != null && !nickname.isBlank())
+                || startDate != null
+                || endDate != null;
+
+        if (!hasSearchCondition) {
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
         }
 


### PR DESCRIPTION
## 작업 내용
- `betweenDate()` 메서드 로직 개선
  -  **startDate만 있을 때:** createdAt >= startDate 00:00:00 조건 생성
  -  **endDate만 있을 때:** createdAt <= endDate 23:59:59 조건 생성
  - **두 값 모두 있을 때:** 두 조건을 AND로 결합

## 테스트 결과
- startDate만 전달 → 시작일 이상 데이터만 정상 조회 확인
- endDate만 전달 → 종료일 이하 데이터만 정상 조회 확인
- startDate와 endDate 모두 전달 → 날짜 구간 내 데이터만 정상 조회 확인