### PR TITLE
feat: 매니저 등록 요청 로그 독립 트랜잭션으로 기록

### DIFF
--- a/src/main/java/org/example/expert/domain/common/entity/CreatedAtEntity.java
+++ b/src/main/java/org/example/expert/domain/common/entity/CreatedAtEntity.java
@@ -1,0 +1,18 @@
+package org.example.expert.domain.common.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class CreatedAtEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/expert/domain/manager/entity/Log.java
+++ b/src/main/java/org/example/expert/domain/manager/entity/Log.java
@@ -1,0 +1,24 @@
+package org.example.expert.domain.manager.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.expert.domain.common.entity.CreatedAtEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Log extends CreatedAtEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long menagerId;
+
+    public Log(Long menagerId) {
+        this.menagerId = menagerId;
+    }
+}

--- a/src/main/java/org/example/expert/domain/manager/repository/ManagerLogRepository.java
+++ b/src/main/java/org/example/expert/domain/manager/repository/ManagerLogRepository.java
@@ -1,0 +1,7 @@
+package org.example.expert.domain.manager.repository;
+
+import org.example.expert.domain.manager.entity.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerLogRepository extends JpaRepository<Log, Long> {
+}

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerLogService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerLogService.java
@@ -1,0 +1,21 @@
+package org.example.expert.domain.manager.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.expert.domain.manager.entity.Log;
+import org.example.expert.domain.manager.repository.ManagerLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerLogService {
+
+    private final ManagerLogRepository managerLogRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveManagerLog(Long managerId) {
+        Log log = new Log(managerId);
+        managerLogRepository.save(log);
+    }
+}

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -28,9 +28,13 @@ public class ManagerService {
     private final ManagerRepository managerRepository;
     private final UserRepository userRepository;
     private final TodoRepository todoRepository;
+    private final ManagerLogService managerLogService;
 
     @Transactional
     public ManagerSaveResponse saveManager(AuthUser authUser, long todoId, ManagerSaveRequest managerSaveRequest) {
+
+        managerLogService.saveManagerLog(managerSaveRequest.getManagerUserId());
+
         // 일정을 만든 유저
         User user = User.fromAuthUser(authUser);
         Todo todo = todoRepository.findById(todoId)


### PR DESCRIPTION
## 작업 내용
- `log` 테이블 추가
- `ManagerLogService `추가 및 `saveManagerLog()` 메서드 구현
  - 매니저 요청 로그를 독립 **트랜잭션(REQUIRES_NEW)** 으로 저장
  - 로그 엔티티에는 `managerId`와 생성 시간(`createdAt`)만 기록
- `ManagerService`에서 매니저 등록 시 로그 호출 추가
- 매니저 등록 실패 여부와 상관없이 로그가 항상 남도록 구현

## 테스트 결과
- 매니저 등록 성공 시 → 로그 정상 기록 확인
- 매니저 등록 실패 시 → 로그 여전히 기록됨